### PR TITLE
Falcon model for bandit parameter evaluation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.11</version>
+            <version>1.4.12</version>
         </dependency>
         <dependency>
             <groupId>org.ehcache</groupId>

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -157,6 +157,8 @@ public class EppoClient {
         String banditKey = assignmentResult.getVariation().getTypedValue().stringValue();
         BanditParameters banditParameters = this.configurationStore.getBanditParameters(banditKey);
 
+        System.out.println(">>>> "+banditKey+" parameters >>>>>"+banditParameters);
+
         List<Variation> actionVariations = BanditEvaluator.evaluateBanditActions(
           assignmentResult.getExperimentKey(),
           banditParameters,
@@ -452,6 +454,8 @@ public class EppoClient {
             int subjectShards,
             float percentageExposure) {
         int shard = Shard.getShard("exposure-" + subjectKey + "-" + experimentKey, subjectShards);
+        System.out.println(">>>> shard "+shard);
+        System.out.println(">>>> exposure shards " + (percentageExposure * subjectShards));
         return shard <= percentageExposure * subjectShards;
     }
 

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -154,15 +154,12 @@ public class EppoClient {
     private Optional<EppoValue> determineAndLogBanditAction(VariationAssignmentResult assignmentResult, Map<String, EppoAttributes> assignmentOptions) {
         String banditName = assignmentResult.getVariation().getTypedValue().stringValue();
 
-        // Properties of the bandit model are hardcoded for now
-        // These would be pulled from the RAC
-        String modelName = "random";
-        String modelVersion = "0.1";
-        String modelVersionToLog = modelName + " " + modelVersion;
+        String banditKey = assignmentResult.getVariation().getTypedValue().stringValue();
+        BanditParameters banditParameters = this.configurationStore.getBanditParameters(banditKey);
 
         List<Variation> actionVariations = BanditEvaluator.evaluateBanditActions(
           assignmentResult.getExperimentKey(),
-          modelName,
+          banditParameters,
           assignmentOptions,
           assignmentResult.getSubjectKey(),
           assignmentResult.getSubjectAttributes(),
@@ -179,12 +176,18 @@ public class EppoClient {
         if (this.eppoClientConfig.getBanditLogger() != null) {
             // Do bandit-specific logging
 
+            String modelVersionToLog = "cold start"; // Default if we have not seen this bandit before
+            if (banditParameters != null) {
+                modelVersionToLog = banditParameters.getModelName() + " " + banditParameters.getModelVersion();
+            }
+
             // Get the action-related attributes
             EppoAttributes actionAttributes = new EppoAttributes();
             if (assignmentOptions != null && !assignmentOptions.isEmpty()) {
                 actionAttributes = assignmentOptions.get(actionString);
             }
 
+            // TODO FF-1546: break out logging the attributes by numeric and categorical
             this.eppoClientConfig.getBanditLogger().logBanditAction(new BanditLogData(
               assignmentResult.getExperimentKey(),
               banditName,

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -157,8 +157,6 @@ public class EppoClient {
         String banditKey = assignmentResult.getVariation().getTypedValue().stringValue();
         BanditParameters banditParameters = this.configurationStore.getBanditParameters(banditKey);
 
-        System.out.println(">>>> "+banditKey+" parameters >>>>>"+banditParameters);
-
         List<Variation> actionVariations = BanditEvaluator.evaluateBanditActions(
           assignmentResult.getExperimentKey(),
           banditParameters,
@@ -454,8 +452,6 @@ public class EppoClient {
             int subjectShards,
             float percentageExposure) {
         int shard = Shard.getShard("exposure-" + subjectKey + "-" + experimentKey, subjectShards);
-        System.out.println(">>>> shard "+shard);
-        System.out.println(">>>> exposure shards " + (percentageExposure * subjectShards));
         return shard <= percentageExposure * subjectShards;
     }
 

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -176,7 +176,7 @@ public class EppoClient {
         if (this.eppoClientConfig.getBanditLogger() != null) {
             // Do bandit-specific logging
 
-            String modelVersionToLog = "cold start"; // Default if we have not seen this bandit before
+            String modelVersionToLog = "cold start"; // Default model "version" if we have not seen this bandit before or don't have model parameters for it
             if (banditParameters != null) {
                 modelVersionToLog = banditParameters.getModelName() + " " + banditParameters.getModelVersion();
             }

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -176,7 +176,7 @@ public class EppoClient {
         if (this.eppoClientConfig.getBanditLogger() != null) {
             // Do bandit-specific logging
 
-            String modelVersionToLog = "cold start"; // Default model "version" if we have not seen this bandit before or don't have model parameters for it
+            String modelVersionToLog = "uninitialized"; // Default model "version" if we have not seen this bandit before or don't have model parameters for it
             if (banditParameters != null) {
                 modelVersionToLog = banditParameters.getModelName() + " " + banditParameters.getModelVersion();
             }

--- a/src/main/java/com/eppo/sdk/deserializer/BanditsDeserializer.java
+++ b/src/main/java/com/eppo/sdk/deserializer/BanditsDeserializer.java
@@ -33,19 +33,23 @@ public class BanditsDeserializer extends StdDeserializer<Map<String, BanditParam
             String updatedAtStr = banditNode.get("updatedAt").asText();
             Instant instant = Instant.parse(updatedAtStr);
             Date updatedAt = Date.from(instant);
-            String model = banditNode.get("model").asText();
+            String modelName = banditNode.get("modelName").asText();
             String modelVersion = banditNode.get("modelVersion").asText();
 
             BanditParameters parameters = new BanditParameters();
             parameters.setBanditKey(banditKey);
             parameters.setUpdatedAt(updatedAt);
-            parameters.setModelName(model);
+            parameters.setModelName(modelName);
             parameters.setModelVersion(modelVersion);
 
             BanditModelData modelData = new BanditModelData();
             JsonNode modelDataNode = banditNode.get("modelData");
             double gamma = modelDataNode.get("gamma").asDouble();
             modelData.setGamma(gamma);
+            double defaultActionScore = modelDataNode.get("defaultActionScore").asDouble();
+            modelData.setDefaultActionScore(defaultActionScore);
+            double actionProbabilityFloor = modelDataNode.get("actionProbabilityFloor").asDouble();
+            modelData.setActionProbabilityFloor(actionProbabilityFloor);
             JsonNode coefficientsNode = modelDataNode.get("coefficients");
 
             Map<String, BanditCoefficients> coefficients = new HashMap<>();

--- a/src/main/java/com/eppo/sdk/deserializer/BanditsDeserializer.java
+++ b/src/main/java/com/eppo/sdk/deserializer/BanditsDeserializer.java
@@ -39,7 +39,7 @@ public class BanditsDeserializer extends StdDeserializer<Map<String, BanditParam
             BanditParameters parameters = new BanditParameters();
             parameters.setBanditKey(banditKey);
             parameters.setUpdatedAt(updatedAt);
-            parameters.setModel(model);
+            parameters.setModelName(model);
             parameters.setModelVersion(modelVersion);
 
             BanditModelData modelData = new BanditModelData();

--- a/src/main/java/com/eppo/sdk/dto/AttributeCoefficients.java
+++ b/src/main/java/com/eppo/sdk/dto/AttributeCoefficients.java
@@ -2,6 +2,6 @@ package com.eppo.sdk.dto;
 
 public interface AttributeCoefficients {
 
-  public String getAttributeKey();
-  public double scoreForAttributeValue(EppoValue attributeValue);
+  String getAttributeKey();
+  double scoreForAttributeValue(EppoValue attributeValue);
 }

--- a/src/main/java/com/eppo/sdk/dto/AttributeCoefficients.java
+++ b/src/main/java/com/eppo/sdk/dto/AttributeCoefficients.java
@@ -1,0 +1,7 @@
+package com.eppo.sdk.dto;
+
+public interface AttributeCoefficients {
+
+  public String getAttributeKey();
+  public double scoreForAttributeValue(EppoValue attributeValue);
+}

--- a/src/main/java/com/eppo/sdk/dto/BanditCategoricalAttributeCoefficients.java
+++ b/src/main/java/com/eppo/sdk/dto/BanditCategoricalAttributeCoefficients.java
@@ -5,8 +5,19 @@ import lombok.Data;
 import java.util.Map;
 
 @Data
-public class BanditCategoricalAttributeCoefficients {
+public class BanditCategoricalAttributeCoefficients implements AttributeCoefficients {
   private String attributeKey;
   private Double missingValueCoefficient;
   private Map<String, Double> valueCoefficients;
+
+  public double scoreForAttributeValue(EppoValue attributeValue) {
+    Double coefficient = null;
+    if (attributeValue != null && !attributeValue.isNumeric()) {
+      String valueKey = attributeValue.toString();
+      coefficient = valueCoefficients.get(valueKey);
+    }
+
+    // Categorical attributes are treated as one-hot booleans, so it's just the coefficient * 1 when present
+    return coefficient != null ? coefficient : missingValueCoefficient;
+  }
 }

--- a/src/main/java/com/eppo/sdk/dto/BanditCategoricalAttributeCoefficients.java
+++ b/src/main/java/com/eppo/sdk/dto/BanditCategoricalAttributeCoefficients.java
@@ -1,9 +1,11 @@
 package com.eppo.sdk.dto;
 
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
 
+@Slf4j
 @Data
 public class BanditCategoricalAttributeCoefficients implements AttributeCoefficients {
   private String attributeKey;
@@ -11,11 +13,16 @@ public class BanditCategoricalAttributeCoefficients implements AttributeCoeffici
   private Map<String, Double> valueCoefficients;
 
   public double scoreForAttributeValue(EppoValue attributeValue) {
-    Double coefficient = null;
-    if (attributeValue != null && !attributeValue.isNumeric()) {
-      String valueKey = attributeValue.toString();
-      coefficient = valueCoefficients.get(valueKey);
+    if (attributeValue == null || attributeValue.isNull()) {
+      return missingValueCoefficient;
     }
+    if (attributeValue.isNumeric()) {
+      log.warn("Unexpected numeric attribute value for attribute "+attributeKey);
+      return missingValueCoefficient;
+    }
+
+    String valueKey = attributeValue.toString();
+    Double coefficient = valueCoefficients.get(valueKey);
 
     // Categorical attributes are treated as one-hot booleans, so it's just the coefficient * 1 when present
     return coefficient != null ? coefficient : missingValueCoefficient;

--- a/src/main/java/com/eppo/sdk/dto/BanditModelData.java
+++ b/src/main/java/com/eppo/sdk/dto/BanditModelData.java
@@ -7,5 +7,7 @@ import java.util.Map;
 @Data
 public class BanditModelData {
   private Double gamma;
+  private Double defaultActionScore;
+  private Double actionProbabilityFloor;
   private Map<String, BanditCoefficients> coefficients;
 }

--- a/src/main/java/com/eppo/sdk/dto/BanditNumericAttributeCoefficients.java
+++ b/src/main/java/com/eppo/sdk/dto/BanditNumericAttributeCoefficients.java
@@ -1,7 +1,9 @@
 package com.eppo.sdk.dto;
 
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Data
 public class BanditNumericAttributeCoefficients implements AttributeCoefficients {
   private String attributeKey;
@@ -9,6 +11,12 @@ public class BanditNumericAttributeCoefficients implements AttributeCoefficients
   private Double missingValueCoefficient;
 
   public double scoreForAttributeValue(EppoValue attributeValue) {
-    return attributeValue != null && attributeValue.isNumeric() ? coefficient * attributeValue.doubleValue() : missingValueCoefficient;
+    if (attributeValue == null || attributeValue.isNull()) {
+      return missingValueCoefficient;
+    }
+    if (!attributeValue.isNumeric()) {
+      log.warn("Unexpected categorical attribute value for attribute "+attributeKey);
+    }
+    return coefficient * attributeValue.doubleValue();
   }
 }

--- a/src/main/java/com/eppo/sdk/dto/BanditNumericAttributeCoefficients.java
+++ b/src/main/java/com/eppo/sdk/dto/BanditNumericAttributeCoefficients.java
@@ -3,8 +3,12 @@ package com.eppo.sdk.dto;
 import lombok.Data;
 
 @Data
-public class BanditNumericAttributeCoefficients {
+public class BanditNumericAttributeCoefficients implements AttributeCoefficients {
   private String attributeKey;
   private Double coefficient;
   private Double missingValueCoefficient;
+
+  public double scoreForAttributeValue(EppoValue attributeValue) {
+    return attributeValue != null && attributeValue.isNumeric() ? coefficient * attributeValue.doubleValue() : missingValueCoefficient;
+  }
 }

--- a/src/main/java/com/eppo/sdk/dto/BanditParameters.java
+++ b/src/main/java/com/eppo/sdk/dto/BanditParameters.java
@@ -7,7 +7,7 @@ import lombok.Data;
 public class BanditParameters {
   private String banditKey;
   private Date updatedAt;
-  private String model;
+  private String modelName;
   private String modelVersion;
   private BanditModelData modelData;
 }

--- a/src/main/java/com/eppo/sdk/dto/EppoAttributes.java
+++ b/src/main/java/com/eppo/sdk/dto/EppoAttributes.java
@@ -1,8 +1,18 @@
 package com.eppo.sdk.dto;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Subject Attributes Class
  */
-public class EppoAttributes extends HashMap<String, EppoValue> {}
+public class EppoAttributes extends HashMap<String, EppoValue> {
+
+  public EppoAttributes() {
+    super();
+  }
+
+  public EppoAttributes(Map<String, EppoValue> initialValues) {
+    super(initialValues);
+  }
+}

--- a/src/main/java/com/eppo/sdk/dto/EppoValue.java
+++ b/src/main/java/com/eppo/sdk/dto/EppoValue.java
@@ -88,6 +88,7 @@ public class EppoValue {
             Double.parseDouble(value);
             return true;
         } catch (Exception e) {
+            System.out.println("EXCEPTION PARSING "+value+" "+e.getMessage());
             return false;
         }
     }

--- a/src/main/java/com/eppo/sdk/dto/EppoValue.java
+++ b/src/main/java/com/eppo/sdk/dto/EppoValue.java
@@ -88,7 +88,6 @@ public class EppoValue {
             Double.parseDouble(value);
             return true;
         } catch (Exception e) {
-            System.out.println("EXCEPTION PARSING "+value+" "+e.getMessage());
             return false;
         }
     }

--- a/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
+++ b/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
@@ -89,6 +89,10 @@ public class ConfigurationStore {
 
     }
 
+    public BanditParameters getBanditParameters(String banditKey) {
+        return this.banditParametersCache.get(banditKey);
+    }
+
     /**
      * This function is used to set experiment configuration int the cache
      *

--- a/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
+++ b/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
@@ -123,12 +123,14 @@ public class ConfigurationStore {
         }
 
         if (loadBandits) {
+            System.out.println(">>>> loading bandits");
             Optional<BanditParametersResponse> banditResponse = this.banditParametersRequestor.fetchConfiguration();
             if (banditResponse.isEmpty() || banditResponse.get().getBandits() == null) {
                 log.warn("Unexpected empty bandit parameter response");
                 return;
             }
             for (Map.Entry<String, BanditParameters> entry : banditResponse.get().getBandits().entrySet()) {
+                System.out.println(">>>> saving bandit parameters for "+entry.getKey());
                 this.banditParametersCache.put(entry.getKey(), entry.getValue());
             }
         }

--- a/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
+++ b/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
@@ -123,14 +123,12 @@ public class ConfigurationStore {
         }
 
         if (loadBandits) {
-            System.out.println(">>>> loading bandits");
             Optional<BanditParametersResponse> banditResponse = this.banditParametersRequestor.fetchConfiguration();
             if (banditResponse.isEmpty() || banditResponse.get().getBandits() == null) {
                 log.warn("Unexpected empty bandit parameter response");
                 return;
             }
             for (Map.Entry<String, BanditParameters> entry : banditResponse.get().getBandits().entrySet()) {
-                System.out.println(">>>> saving bandit parameters for "+entry.getKey());
                 this.banditParametersCache.put(entry.getKey(), entry.getValue());
             }
         }

--- a/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
@@ -23,6 +23,7 @@ public class BanditEvaluator {
         String modelName = modelParameters != null ? modelParameters.getModelName() : "random";
         BanditModel model = BanditModelFactory.build(modelName);
         Map<String, Double> actionWeights = model.weighActions(modelParameters, actions, subjectAttributes);
+        System.out.println(">>> action weights"+actionWeights);
         List<String> shuffledActions = shuffleActions(actions.keySet(), experimentKey, subjectKey);
         return generateVariations(shuffledActions, actionWeights, subjectShards);
     }

--- a/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
@@ -1,9 +1,6 @@
 package com.eppo.sdk.helpers.bandit;
 
-import com.eppo.sdk.dto.EppoAttributes;
-import com.eppo.sdk.dto.EppoValue;
-import com.eppo.sdk.dto.ShardRange;
-import com.eppo.sdk.dto.Variation;
+import com.eppo.sdk.dto.*;
 import com.eppo.sdk.helpers.Shard;
 
 import java.util.Comparator;
@@ -17,14 +14,15 @@ public class BanditEvaluator {
 
     public static List<Variation> evaluateBanditActions(
         String experimentKey,
-        String modelName,
+        BanditParameters modelParameters,
         Map<String, EppoAttributes> actions,
         String subjectKey,
         EppoAttributes subjectAttributes,
         int subjectShards
     ) {
+        String modelName = modelParameters != null ? modelParameters.getModelName() : "random";
         BanditModel model = BanditModelFactory.build(modelName);
-        Map<String, Float> actionWeights = model.weighActions(actions, subjectAttributes);
+        Map<String, Float> actionWeights = model.weighActions(modelParameters, actions, subjectAttributes);
         List<String> shuffledActions = shuffleActions(actions.keySet(), experimentKey, subjectKey);
         return generateVariations(shuffledActions, actionWeights, subjectShards);
     }

--- a/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
@@ -20,7 +20,10 @@ public class BanditEvaluator {
         EppoAttributes subjectAttributes,
         int subjectShards
     ) {
-        String modelName = modelParameters != null ? modelParameters.getModelName() : "random";
+        String modelName = modelParameters != null
+          ? modelParameters.getModelName()
+          : RandomBanditModel.MODEL_IDENTIFIER; // Default to random model for unknown bandits
+
         BanditModel model = BanditModelFactory.build(modelName);
         Map<String, Double> actionWeights = model.weighActions(modelParameters, actions, subjectAttributes);
         List<String> shuffledActions = shuffleActions(actions.keySet(), experimentKey, subjectKey);

--- a/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
@@ -23,6 +23,7 @@ public class BanditEvaluator {
         String modelName = modelParameters != null ? modelParameters.getModelName() : "random";
         BanditModel model = BanditModelFactory.build(modelName);
         Map<String, Double> actionWeights = model.weighActions(modelParameters, actions, subjectAttributes);
+        System.out.println(">>>> action weights "+actionWeights);
         List<String> shuffledActions = shuffleActions(actions.keySet(), experimentKey, subjectKey);
         return generateVariations(shuffledActions, actionWeights, subjectShards);
     }

--- a/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
@@ -22,7 +22,7 @@ public class BanditEvaluator {
     ) {
         String modelName = modelParameters != null ? modelParameters.getModelName() : "random";
         BanditModel model = BanditModelFactory.build(modelName);
-        Map<String, Float> actionWeights = model.weighActions(modelParameters, actions, subjectAttributes);
+        Map<String, Double> actionWeights = model.weighActions(modelParameters, actions, subjectAttributes);
         List<String> shuffledActions = shuffleActions(actions.keySet(), experimentKey, subjectKey);
         return generateVariations(shuffledActions, actionWeights, subjectShards);
     }
@@ -40,12 +40,12 @@ public class BanditEvaluator {
         return Shard.getShard(experimentKey+"-"+subjectKey+"-"+actionKey, SHUFFLE_SHARDS);
     }
 
-    private static List<Variation> generateVariations(List<String> shuffledActions, Map<String, Float>  actionWeights, int subjectShards) {
+    private static List<Variation> generateVariations(List<String> shuffledActions, Map<String, Double>  actionWeights, int subjectShards) {
 
         final AtomicInteger lastShard = new AtomicInteger(0);
 
         List<Variation> variations = shuffledActions.stream().map(actionName -> {
-            float weight = actionWeights.get(actionName);
+            double weight = actionWeights.get(actionName);
             int numShards = Double.valueOf(Math.floor(weight * subjectShards)).intValue();
             int shardStart = lastShard.get();
             int shardEnd = shardStart + numShards;

--- a/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
@@ -23,7 +23,6 @@ public class BanditEvaluator {
         String modelName = modelParameters != null ? modelParameters.getModelName() : "random";
         BanditModel model = BanditModelFactory.build(modelName);
         Map<String, Double> actionWeights = model.weighActions(modelParameters, actions, subjectAttributes);
-        System.out.println(">>>> action weights "+actionWeights);
         List<String> shuffledActions = shuffleActions(actions.keySet(), experimentKey, subjectKey);
         return generateVariations(shuffledActions, actionWeights, subjectShards);
     }

--- a/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/BanditEvaluator.java
@@ -23,7 +23,6 @@ public class BanditEvaluator {
         String modelName = modelParameters != null ? modelParameters.getModelName() : "random";
         BanditModel model = BanditModelFactory.build(modelName);
         Map<String, Double> actionWeights = model.weighActions(modelParameters, actions, subjectAttributes);
-        System.out.println(">>> action weights"+actionWeights);
         List<String> shuffledActions = shuffleActions(actions.keySet(), experimentKey, subjectKey);
         return generateVariations(shuffledActions, actionWeights, subjectShards);
     }

--- a/src/main/java/com/eppo/sdk/helpers/bandit/BanditModel.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/BanditModel.java
@@ -1,11 +1,12 @@
 package com.eppo.sdk.helpers.bandit;
 
+import com.eppo.sdk.dto.BanditParameters;
 import com.eppo.sdk.dto.EppoAttributes;
 
 import java.util.Map;
 
 public interface BanditModel {
 
-    Map<String, Float> weighActions(Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes);
+    Map<String, Float> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes);
 
 }

--- a/src/main/java/com/eppo/sdk/helpers/bandit/BanditModel.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/BanditModel.java
@@ -7,6 +7,6 @@ import java.util.Map;
 
 public interface BanditModel {
 
-    Map<String, Float> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes);
+    Map<String, Double> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes);
 
 }

--- a/src/main/java/com/eppo/sdk/helpers/bandit/BanditModelFactory.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/BanditModelFactory.java
@@ -5,6 +5,8 @@ public class BanditModelFactory {
         switch(modelName) {
             case "random":
                 return new RandomBanditModel();
+            case "falcon":
+                return new FalconBanditModel();
             default:
                 throw new IllegalArgumentException("Unknown bandit model " + modelName);
         }

--- a/src/main/java/com/eppo/sdk/helpers/bandit/BanditModelFactory.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/BanditModelFactory.java
@@ -1,11 +1,12 @@
 package com.eppo.sdk.helpers.bandit;
 
 public class BanditModelFactory {
+
     public static BanditModel build(String modelName) {
         switch(modelName) {
-            case "random":
+            case RandomBanditModel.MODEL_IDENTIFIER:
                 return new RandomBanditModel();
-            case "falcon":
+            case FalconBanditModel.MODEL_IDENTIFIER:
                 return new FalconBanditModel();
             default:
                 throw new IllegalArgumentException("Unknown bandit model " + modelName);

--- a/src/main/java/com/eppo/sdk/helpers/bandit/FalconBanditModel.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/FalconBanditModel.java
@@ -8,6 +8,8 @@ import java.util.stream.Collectors;
 
 public class FalconBanditModel implements BanditModel {
 
+  public static final String MODEL_IDENTIFIER = "falcon";
+
   public Map<String, Double> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes) {
 
     // For each action we need to compute its score using the model coefficients

--- a/src/main/java/com/eppo/sdk/helpers/bandit/FalconBanditModel.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/FalconBanditModel.java
@@ -2,56 +2,98 @@ package com.eppo.sdk.helpers.bandit;
 
 import com.eppo.sdk.dto.*;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public class FalconBanditModel implements BanditModel {
 
-    public Map<String, Float> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes) {
+    public Map<String, Double> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes) {
 
-        // For each action we need to compute its weight using the model coefficients
-
-        Map<String, Double> actionWeights = actions.entrySet().stream().collect(Collectors.toMap(
+        // For each action we need to compute its score using the model coefficients
+        Map<String, Double> actionScores = actions.entrySet().stream().collect(Collectors.toMap(
           Map.Entry::getKey,
           e -> {
 
             // get all coefficients known to the model
-            BanditCoefficients actionCoefficients = parameters.getModelData().getCoefficients().get(e.getKey());
+            BanditCoefficients banditCoefficients = parameters.getModelData().getCoefficients().get(e.getKey());
 
-            double actionWeight = 0.0;
+            double actionScore = 0.0;
 
-            for( BanditNumericAttributeCoefficients actionNumericCoefficients : actionCoefficients.getActionNumericCoefficients().values()) {
+            for( BanditNumericAttributeCoefficients actionNumericCoefficients : banditCoefficients.getActionNumericCoefficients().values()) {
               EppoValue actionContextValue = e.getValue().get(actionNumericCoefficients.getAttributeKey());
-              double attributeWeight = actionContextValue != null && actionContextValue.isNumeric()
+              double attributeScore = actionContextValue != null && actionContextValue.isNumeric()
                 ? actionContextValue.doubleValue() * actionNumericCoefficients.getCoefficient()
                 : actionNumericCoefficients.getMissingValueCoefficient();
 
-              actionWeight += attributeWeight;
+              actionScore += attributeScore;
             }
 
-            for( BanditCategoricalAttributeCoefficients actionCategoricalCoefficients : actionCoefficients.getActionCategoricalCoefficients().values()) {
+            for( BanditCategoricalAttributeCoefficients actionCategoricalCoefficients : banditCoefficients.getActionCategoricalCoefficients().values()) {
               EppoValue actionContextValue = e.getValue().get(actionCategoricalCoefficients.getAttributeKey());
               boolean validStringContextValue = actionContextValue != null && actionContextValue.stringValue() != null && !actionContextValue.stringValue().trim().isEmpty();
-              double attributeWeight = validStringContextValue
+              double attributeScore = validStringContextValue
                 ? actionCategoricalCoefficients.getValueCoefficients().get(actionContextValue.stringValue().trim())
                 : actionCategoricalCoefficients.getMissingValueCoefficient();
 
-              actionWeight += attributeWeight;
+              actionScore += attributeScore;
             }
 
-            // TODO: same as above but for subject context
+            for( BanditNumericAttributeCoefficients subjectNumericCoefficients : banditCoefficients.getSubjectNumericCoefficients().values()) {
+              EppoValue actionContextValue = e.getValue().get(subjectNumericCoefficients.getAttributeKey());
+              double attributeScore = actionContextValue != null && actionContextValue.isNumeric()
+                ? actionContextValue.doubleValue() * subjectNumericCoefficients.getCoefficient()
+                : subjectNumericCoefficients.getMissingValueCoefficient();
 
-            return actionWeight;
+              actionScore += attributeScore;
+            }
+
+            for( BanditCategoricalAttributeCoefficients subjectCategoricalCoefficients : banditCoefficients.getSubjectCategoricalCoefficients().values()) {
+              EppoValue actionContextValue = e.getValue().get(subjectCategoricalCoefficients.getAttributeKey());
+              boolean validStringContextValue = actionContextValue != null && actionContextValue.stringValue() != null && !actionContextValue.stringValue().trim().isEmpty();
+              double attributeScore = validStringContextValue
+                ? subjectCategoricalCoefficients.getValueCoefficients().get(actionContextValue.stringValue().trim())
+                : subjectCategoricalCoefficients.getMissingValueCoefficient();
+
+              actionScore += attributeScore;
+            }
+
+            return actionScore;
           }
         ));
 
+        // Find the action with the highest score
+        Double highestScore = null;
+        String highestScoredAction = null;
+        for (Map.Entry<String, Double> actionScore : actionScores.entrySet()) {
+          if (highestScore == null || actionScore.getValue() > highestScore) {
+            highestScore = actionScore.getValue();
+            highestScoredAction = actionScore.getKey();
+          }
+        }
 
+        // Weigh all the actions using their score
+        Map<String, Double> actionWeights = new HashMap<>();
+        Double gamma = 1.0; // hard-coded for now
+        double totalNonHighestWeight = 0.0;
+        for (Map.Entry<String, Double> actionScore : actionScores.entrySet()) {
+          if (actionScore.getKey().equals(highestScoredAction)) {
+            // The highest scored action is weighed at the end
+            continue;
+          }
 
+          // Compute weight and round to four decimal places
+          double  unroundedProbability = 1 / (actionScores.size() + (gamma * (highestScore - actionScore.getValue())));
+          double roundedProbability = Math.round(unroundedProbability * 10000d) / 10000d;
+          totalNonHighestWeight += roundedProbability;
 
-        final float weightPerAction = 1 / (float)actions.size();
-        return actions.keySet().stream().collect(Collectors.toMap(
-            key -> key,
-            value -> weightPerAction
-        ));
+          actionWeights.put(actionScore.getKey(), roundedProbability);
+        }
+
+        // Weigh the highest scoring action
+        double weightForHighestScore = 1 - totalNonHighestWeight;
+        actionWeights.put(highestScoredAction, weightForHighestScore);
+
+        return actionWeights;
     }
 }

--- a/src/main/java/com/eppo/sdk/helpers/bandit/FalconBanditModel.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/FalconBanditModel.java
@@ -14,11 +14,15 @@ public class FalconBanditModel implements BanditModel {
         Map<String, Double> actionScores = actions.entrySet().stream().collect(Collectors.toMap(
           Map.Entry::getKey,
           e -> {
+            double actionScore = 0.0;
 
             // get all coefficients known to the model
             BanditCoefficients banditCoefficients = parameters.getModelData().getCoefficients().get(e.getKey());
 
-            double actionScore = 0.0;
+            if (banditCoefficients == null) {
+              // Unknown action
+              return actionScore;
+            }
 
             for( BanditNumericAttributeCoefficients actionNumericCoefficients : banditCoefficients.getActionNumericCoefficients().values()) {
               EppoValue actionContextValue = e.getValue().get(actionNumericCoefficients.getAttributeKey());

--- a/src/main/java/com/eppo/sdk/helpers/bandit/FalconBanditModel.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/FalconBanditModel.java
@@ -1,0 +1,57 @@
+package com.eppo.sdk.helpers.bandit;
+
+import com.eppo.sdk.dto.*;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class FalconBanditModel implements BanditModel {
+
+    public Map<String, Float> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes) {
+
+        // For each action we need to compute its weight using the model coefficients
+
+        Map<String, Double> actionWeights = actions.entrySet().stream().collect(Collectors.toMap(
+          Map.Entry::getKey,
+          e -> {
+
+            // get all coefficients known to the model
+            BanditCoefficients actionCoefficients = parameters.getModelData().getCoefficients().get(e.getKey());
+
+            double actionWeight = 0.0;
+
+            for( BanditNumericAttributeCoefficients actionNumericCoefficients : actionCoefficients.getActionNumericCoefficients().values()) {
+              EppoValue actionContextValue = e.getValue().get(actionNumericCoefficients.getAttributeKey());
+              double attributeWeight = actionContextValue != null && actionContextValue.isNumeric()
+                ? actionContextValue.doubleValue() * actionNumericCoefficients.getCoefficient()
+                : actionNumericCoefficients.getMissingValueCoefficient();
+
+              actionWeight += attributeWeight;
+            }
+
+            for( BanditCategoricalAttributeCoefficients actionCategoricalCoefficients : actionCoefficients.getActionCategoricalCoefficients().values()) {
+              EppoValue actionContextValue = e.getValue().get(actionCategoricalCoefficients.getAttributeKey());
+              boolean validStringContextValue = actionContextValue != null && actionContextValue.stringValue() != null && !actionContextValue.stringValue().trim().isEmpty();
+              double attributeWeight = validStringContextValue
+                ? actionCategoricalCoefficients.getValueCoefficients().get(actionContextValue.stringValue().trim())
+                : actionCategoricalCoefficients.getMissingValueCoefficient();
+
+              actionWeight += attributeWeight;
+            }
+
+            // TODO: same as above but for subject context
+
+            return actionWeight;
+          }
+        ));
+
+
+
+
+        final float weightPerAction = 1 / (float)actions.size();
+        return actions.keySet().stream().collect(Collectors.toMap(
+            key -> key,
+            value -> weightPerAction
+        ));
+    }
+}

--- a/src/main/java/com/eppo/sdk/helpers/bandit/FalconBanditModel.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/FalconBanditModel.java
@@ -8,99 +8,83 @@ import java.util.stream.Collectors;
 
 public class FalconBanditModel implements BanditModel {
 
-    public Map<String, Double> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes) {
+  public Map<String, Double> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes) {
 
-        // For each action we need to compute its score using the model coefficients
-        Map<String, Double> actionScores = actions.entrySet().stream().collect(Collectors.toMap(
-          Map.Entry::getKey,
-          e -> {
-            double actionScore = 0.0;
+    // For each action we need to compute its score using the model coefficients
+    Map<String, Double> actionScores = actions.entrySet().stream().collect(Collectors.toMap(
+      Map.Entry::getKey, e -> {
+        String actionName = e.getKey();
+        EppoAttributes actionAttributes = e.getValue();
+        double actionScore = 0.0;
 
-            // get all coefficients known to the model
-            BanditCoefficients banditCoefficients = parameters.getModelData().getCoefficients().get(e.getKey());
+        // get all coefficients known to the model for this action
+        BanditCoefficients banditCoefficients = parameters.getModelData().getCoefficients().get(actionName);
 
-            if (banditCoefficients == null) {
-              // Unknown action
-              return actionScore;
-            }
-
-            actionScore += banditCoefficients.getIntercept();
-
-            for( BanditNumericAttributeCoefficients actionNumericCoefficients : banditCoefficients.getActionNumericCoefficients().values()) {
-              EppoValue actionContextValue = e.getValue().get(actionNumericCoefficients.getAttributeKey());
-              double attributeScore = actionContextValue != null && actionContextValue.isNumeric()
-                ? actionContextValue.doubleValue() * actionNumericCoefficients.getCoefficient()
-                : actionNumericCoefficients.getMissingValueCoefficient();
-
-              actionScore += attributeScore;
-            }
-
-            for( BanditCategoricalAttributeCoefficients actionCategoricalCoefficients : banditCoefficients.getActionCategoricalCoefficients().values()) {
-              EppoValue actionContextValue = e.getValue().get(actionCategoricalCoefficients.getAttributeKey());
-              boolean validStringContextValue = actionContextValue != null && actionContextValue.stringValue() != null && !actionContextValue.stringValue().trim().isEmpty();
-              double attributeScore = validStringContextValue
-                ? actionCategoricalCoefficients.getValueCoefficients().get(actionContextValue.stringValue().trim())
-                : actionCategoricalCoefficients.getMissingValueCoefficient();
-
-              actionScore += attributeScore;
-            }
-
-            for( BanditNumericAttributeCoefficients subjectNumericCoefficients : banditCoefficients.getSubjectNumericCoefficients().values()) {
-              EppoValue actionContextValue = subjectAttributes.get(subjectNumericCoefficients.getAttributeKey());
-              double attributeScore = actionContextValue != null && actionContextValue.isNumeric()
-                ? actionContextValue.doubleValue() * subjectNumericCoefficients.getCoefficient()
-                : subjectNumericCoefficients.getMissingValueCoefficient();
-
-              actionScore += attributeScore;
-            }
-
-            for( BanditCategoricalAttributeCoefficients subjectCategoricalCoefficients : banditCoefficients.getSubjectCategoricalCoefficients().values()) {
-              EppoValue actionContextValue = subjectAttributes.get(subjectCategoricalCoefficients.getAttributeKey());
-              boolean validStringContextValue = actionContextValue != null && actionContextValue.stringValue() != null && !actionContextValue.stringValue().trim().isEmpty();
-              double attributeScore = validStringContextValue
-                ? subjectCategoricalCoefficients.getValueCoefficients().get(actionContextValue.stringValue().trim())
-                : subjectCategoricalCoefficients.getMissingValueCoefficient();
-
-              actionScore += attributeScore;
-            }
-
-            return actionScore;
-          }
-        ));
-
-        // Find the action with the highest score
-        Double highestScore = null;
-        String highestScoredAction = null;
-        for (Map.Entry<String, Double> actionScore : actionScores.entrySet()) {
-          if (highestScore == null || actionScore.getValue() > highestScore) {
-            highestScore = actionScore.getValue();
-            highestScoredAction = actionScore.getKey();
-          }
+        if (banditCoefficients == null) {
+          // Unknown action; return default score of 0
+          return actionScore;
         }
 
-        // Weigh all the actions using their score
-        Map<String, Double> actionWeights = new HashMap<>();
-        Double gamma = 1.0; // hard-coded for now
-        double totalNonHighestWeight = 0.0;
-        for (Map.Entry<String, Double> actionScore : actionScores.entrySet()) {
-          if (actionScore.getKey().equals(highestScoredAction)) {
-            // The highest scored action is weighed at the end
-            continue;
-          }
+        actionScore += banditCoefficients.getIntercept();
 
+        actionScore += scoreContextForCoefficients(actionAttributes, banditCoefficients.getActionNumericCoefficients());
+        actionScore += scoreContextForCoefficients(actionAttributes, banditCoefficients.getActionCategoricalCoefficients());
+        actionScore += scoreContextForCoefficients(subjectAttributes, banditCoefficients.getSubjectNumericCoefficients());
+        actionScore += scoreContextForCoefficients(subjectAttributes, banditCoefficients.getSubjectCategoricalCoefficients());
 
-          // Compute weight and round to four decimal places
-          double  unroundedProbability = 1 / (actionScores.size() + (gamma * (highestScore - actionScore.getValue())));
-          double roundedProbability = Math.round(unroundedProbability * 10000d) / 10000d;
-          totalNonHighestWeight += roundedProbability;
+        return actionScore;
+      })
+    );
 
-          actionWeights.put(actionScore.getKey(), roundedProbability);
-        }
+    // Convert to scores to weights (probabilities between 0 and 1 that collectively add up to 1.0)
+    Map<String, Double> actionWeights = computeActionWeights(actionScores);
+    return actionWeights;
+  }
 
-        // Weigh the highest scoring action
-        double weightForHighestScore = 1 - totalNonHighestWeight;
-        actionWeights.put(highestScoredAction, weightForHighestScore);
+  private static double scoreContextForCoefficients(EppoAttributes context, Map<String, ? extends AttributeCoefficients> coefficients) {
 
-        return actionWeights;
+    double totalScore = 0.0;
+
+    for (AttributeCoefficients attributeCoefficients : coefficients.values()) {
+      EppoValue contextValue = context.get(attributeCoefficients.getAttributeKey());
+      double attributeScore = attributeCoefficients.scoreForAttributeValue(contextValue);
+      totalScore += attributeScore;
     }
+
+    return totalScore;
+  }
+
+  private static Map<String, Double> computeActionWeights(Map<String, Double> actionScores) {
+    Double highestScore = null;
+    String highestScoredAction = null;
+    for (Map.Entry<String, Double> actionScore : actionScores.entrySet()) {
+      if (highestScore == null || actionScore.getValue() > highestScore) {
+        highestScore = actionScore.getValue();
+        highestScoredAction = actionScore.getKey();
+      }
+    }
+
+    // Weigh all the actions using their score
+    Map<String, Double> actionWeights = new HashMap<>();
+    double gamma = 1.0; // hard-coded for now
+    double totalNonHighestWeight = 0.0;
+    for (Map.Entry<String, Double> actionScore : actionScores.entrySet()) {
+      if (actionScore.getKey().equals(highestScoredAction)) {
+        // The highest scored action is weighed at the end
+        continue;
+      }
+
+      // Compute weight and round to four decimal places
+      double  unroundedProbability = 1 / (actionScores.size() + (gamma * (highestScore - actionScore.getValue())));
+      double roundedProbability = Math.round(unroundedProbability * 10000d) / 10000d;
+      totalNonHighestWeight += roundedProbability;
+
+      actionWeights.put(actionScore.getKey(), roundedProbability);
+    }
+
+    // Weigh the highest scoring action
+    double weightForHighestScore = 1 - totalNonHighestWeight;
+    actionWeights.put(highestScoredAction, weightForHighestScore);
+    return actionWeights;
+  }
 }

--- a/src/main/java/com/eppo/sdk/helpers/bandit/FalconBanditModel.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/FalconBanditModel.java
@@ -32,8 +32,6 @@ public class FalconBanditModel implements BanditModel {
                 ? actionContextValue.doubleValue() * actionNumericCoefficients.getCoefficient()
                 : actionNumericCoefficients.getMissingValueCoefficient();
 
-              System.out.printf("%s-%s scores %f\n", e.getKey(), actionNumericCoefficients.getAttributeKey(), attributeScore);
-
               actionScore += attributeScore;
             }
 
@@ -44,8 +42,6 @@ public class FalconBanditModel implements BanditModel {
                 ? actionCategoricalCoefficients.getValueCoefficients().get(actionContextValue.stringValue().trim())
                 : actionCategoricalCoefficients.getMissingValueCoefficient();
 
-              System.out.printf("%s-%s scores %s\n", e.getKey(), actionCategoricalCoefficients.getAttributeKey(), attributeScore);
-
               actionScore += attributeScore;
             }
 
@@ -54,12 +50,6 @@ public class FalconBanditModel implements BanditModel {
               double attributeScore = actionContextValue != null && actionContextValue.isNumeric()
                 ? actionContextValue.doubleValue() * subjectNumericCoefficients.getCoefficient()
                 : subjectNumericCoefficients.getMissingValueCoefficient();
-
-              System.out.println(">>>>> e "+e);
-              System.out.println(subjectNumericCoefficients.getAttributeKey()+" context value "+actionContextValue);
-              System.out.println(">>>>>> SUBJECT NC "+subjectNumericCoefficients);
-
-              System.out.printf("%s-%s scores %f\n", e.getKey(), subjectNumericCoefficients.getAttributeKey(), attributeScore);
 
               actionScore += attributeScore;
             }
@@ -71,16 +61,12 @@ public class FalconBanditModel implements BanditModel {
                 ? subjectCategoricalCoefficients.getValueCoefficients().get(actionContextValue.stringValue().trim())
                 : subjectCategoricalCoefficients.getMissingValueCoefficient();
 
-              System.out.printf("%s-%s scores %s\n", e.getKey(), subjectCategoricalCoefficients.getAttributeKey(), attributeScore);
-
               actionScore += attributeScore;
             }
 
             return actionScore;
           }
         ));
-
-        System.out.println(">>>>>> action scores >>>>>" +actionScores);
 
         // Find the action with the highest score
         Double highestScore = null;
@@ -106,7 +92,6 @@ public class FalconBanditModel implements BanditModel {
           // Compute weight and round to four decimal places
           double  unroundedProbability = 1 / (actionScores.size() + (gamma * (highestScore - actionScore.getValue())));
           double roundedProbability = Math.round(unroundedProbability * 10000d) / 10000d;
-          System.out.printf("%s -> 1 / (%d + %f * (%f - %f)) = %f (%f)\n", actionScore.getKey(), actionScores.size(), gamma, highestScore, actionScore.getValue(), unroundedProbability, roundedProbability);
           totalNonHighestWeight += roundedProbability;
 
           actionWeights.put(actionScore.getKey(), roundedProbability);

--- a/src/main/java/com/eppo/sdk/helpers/bandit/RandomBanditModel.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/RandomBanditModel.java
@@ -8,6 +8,8 @@ import java.util.stream.Collectors;
 
 public class RandomBanditModel implements BanditModel {
 
+    public static final String MODEL_IDENTIFIER = "random";
+
     public Map<String, Double> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes) {
         final double weightPerAction = 1 / (double)actions.size();
         return actions.keySet().stream().collect(Collectors.toMap(

--- a/src/main/java/com/eppo/sdk/helpers/bandit/RandomBanditModel.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/RandomBanditModel.java
@@ -1,5 +1,6 @@
 package com.eppo.sdk.helpers.bandit;
 
+import com.eppo.sdk.dto.BanditParameters;
 import com.eppo.sdk.dto.EppoAttributes;
 
 import java.util.Map;
@@ -7,7 +8,7 @@ import java.util.stream.Collectors;
 
 public class RandomBanditModel implements BanditModel {
 
-    public Map<String, Float> weighActions(Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes) {
+    public Map<String, Float> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes) {
         final float weightPerAction = 1 / (float)actions.size();
         return actions.keySet().stream().collect(Collectors.toMap(
             key -> key,

--- a/src/main/java/com/eppo/sdk/helpers/bandit/RandomBanditModel.java
+++ b/src/main/java/com/eppo/sdk/helpers/bandit/RandomBanditModel.java
@@ -8,8 +8,8 @@ import java.util.stream.Collectors;
 
 public class RandomBanditModel implements BanditModel {
 
-    public Map<String, Float> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes) {
-        final float weightPerAction = 1 / (float)actions.size();
+    public Map<String, Double> weighActions(BanditParameters parameters, Map<String, EppoAttributes> actions, EppoAttributes subjectAttributes) {
+        final double weightPerAction = 1 / (double)actions.size();
         return actions.keySet().stream().collect(Collectors.toMap(
             key -> key,
             value -> weightPerAction

--- a/src/test/java/com/eppo/sdk/EppoClientTest.java
+++ b/src/test/java/com/eppo/sdk/EppoClientTest.java
@@ -335,7 +335,7 @@ public class EppoClientTest {
       "puma", new EppoAttributes(Map.of())
     );
 
-    // get a nike assignment
+    // Get our assigned action
     Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
       "subject2",
       "banner-bandit-experiment",
@@ -397,7 +397,7 @@ public class EppoClientTest {
         ))
     );
 
-    // get a nike assignment
+    // Get our assigned action
     Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
       "subject30",
       "banner-bandit-experiment",
@@ -419,7 +419,7 @@ public class EppoClientTest {
     EppoAttributes subjectAttributes = new EppoAttributes();
     Set<String> actions = Set.of("nike", "adidas", "puma");
 
-    // get a nike assignment
+    // Get our assigned action
     Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
       "subject39",
       "banner-bandit-experiment",

--- a/src/test/java/com/eppo/sdk/EppoClientTest.java
+++ b/src/test/java/com/eppo/sdk/EppoClientTest.java
@@ -265,13 +265,13 @@ public class EppoClientTest {
   }
 
   @Test
-  public void testBanditBanditColdStartAction() {
+  public void testBanditColdStartAction() {
     // For now, use our special bandits RAC until we fold it into the shared test case suite
     String racResponseJson = getMockRandomizedAssignmentResponse("src/test/resources/bandits/rac-experiments-bandits-beta.json");
     this.mockServer.stubFor(
       WireMock.get(WireMock.urlMatching(".*randomized_assignment/v3/config\\?.*")).willReturn(WireMock.okJson(racResponseJson))
     );
-    //this.addBanditRacToMockServer(this.mockServer, "src/test/resources/bandits/bandits-parameters-1.json");
+    this.addBanditRacToMockServer(this.mockServer, "src/test/resources/bandits/bandits-parameters-1.json");
 
     // Re-initialize client with our bandit RAC and a mock logger we can spy on
     IAssignmentLogger mockAssignmentLogger = mock();
@@ -288,8 +288,8 @@ public class EppoClientTest {
 
     // Attempt to get a bandit assignment
     Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
-      "subject1",
-      "cold-start-bandit",
+      "subject2",
+      "cold-start-bandit-experiment",
       new EppoAttributes(),
       banditActions
     );
@@ -302,20 +302,20 @@ public class EppoClientTest {
     ArgumentCaptor<AssignmentLogData> assignmentLogCaptor = ArgumentCaptor.forClass(AssignmentLogData.class);
     verify(mockAssignmentLogger, times(1)).logAssignment(assignmentLogCaptor.capture());
     AssignmentLogData capturedAssignmentLog = assignmentLogCaptor.getValue();
-    assertEquals("cold-start-bandit-bandit", capturedAssignmentLog.experiment);
-    assertEquals("cold-start-bandit", capturedAssignmentLog.featureFlag);
+    assertEquals("cold-start-bandit-experiment-bandit", capturedAssignmentLog.experiment);
+    assertEquals("cold-start-bandit-experiment", capturedAssignmentLog.featureFlag);
     assertEquals("bandit", capturedAssignmentLog.allocation);
-    assertEquals("banner-bandit", capturedAssignmentLog.variation);
-    assertEquals("subject1", capturedAssignmentLog.subject);
+    assertEquals("cold-start-bandit", capturedAssignmentLog.variation);
+    assertEquals("subject2", capturedAssignmentLog.subject);
     assertEquals(Map.of(), capturedAssignmentLog.subjectAttributes);
 
     // Verify bandit log
     ArgumentCaptor<BanditLogData> banditLogCaptor = ArgumentCaptor.forClass(BanditLogData.class);
     verify(mockBanditLogger, times(1)).logBanditAction(banditLogCaptor.capture());
     BanditLogData capturedBanditLog = banditLogCaptor.getValue();
-    assertEquals("cold-start-bandit-bandit", capturedBanditLog.experiment);
-    assertEquals("banner-bandit", capturedBanditLog.variation);
-    assertEquals("subject1", capturedBanditLog.subject);
+    assertEquals("cold-start-bandit-experiment-bandit", capturedBanditLog.experiment);
+    assertEquals("cold-start-bandit", capturedBanditLog.variation);
+    assertEquals("subject2", capturedBanditLog.subject);
     assertEquals(Map.of(), capturedBanditLog.subjectAttributes);
     assertEquals("option3", capturedBanditLog.action);
     assertEquals(Map.of(), capturedBanditLog.actionAttributes);
@@ -324,7 +324,7 @@ public class EppoClientTest {
   }
 
   @Test
-  public void testBanditBanditModelAction() {
+  public void testBanditModelAction() {
     // For now, use our special bandits RAC until we fold it into the shared test case suite
     String racResponseJson = getMockRandomizedAssignmentResponse("src/test/resources/bandits/rac-experiments-bandits-beta.json");
     this.mockServer.stubFor(
@@ -416,8 +416,8 @@ public class EppoClientTest {
 
     // Attempt to get a bandit assignment
     Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
-            "subject8",
-            "cold-start-bandit",
+            "subject10",
+            "cold-start-bandit-experiment",
             new EppoAttributes(),
             banditActions
     );
@@ -428,8 +428,8 @@ public class EppoClientTest {
 
     // Manually log an action
     EppoClient.getInstance().logNonBanditAction(
-      "subject8",
-      "cold-start-bandit",
+      "subject10",
+      "cold-start-bandit-experiment",
       new EppoAttributes(),
       "option0",
       new EppoAttributes()
@@ -439,20 +439,20 @@ public class EppoClientTest {
     ArgumentCaptor<AssignmentLogData> assignmentLogCaptor = ArgumentCaptor.forClass(AssignmentLogData.class);
     verify(mockAssignmentLogger, times(1)).logAssignment(assignmentLogCaptor.capture());
     AssignmentLogData capturedAssignmentLog = assignmentLogCaptor.getValue();
-    assertEquals("cold-start-bandit-bandit", capturedAssignmentLog.experiment);
-    assertEquals("cold-start-bandit", capturedAssignmentLog.featureFlag);
+    assertEquals("cold-start-bandit-experiment-bandit", capturedAssignmentLog.experiment);
+    assertEquals("cold-start-bandit-experiment", capturedAssignmentLog.featureFlag);
     assertEquals("bandit", capturedAssignmentLog.allocation);
     assertEquals("control", capturedAssignmentLog.variation);
-    assertEquals("subject8", capturedAssignmentLog.subject);
+    assertEquals("subject10", capturedAssignmentLog.subject);
     assertEquals(Map.of(), capturedAssignmentLog.subjectAttributes);
 
     // Verify bandit log
     ArgumentCaptor<BanditLogData> banditLogCaptor = ArgumentCaptor.forClass(BanditLogData.class);
     verify(mockBanditLogger, times(1)).logBanditAction(banditLogCaptor.capture());
     BanditLogData capturedBanditLog = banditLogCaptor.getValue();
-    assertEquals("cold-start-bandit-bandit", capturedBanditLog.experiment);
+    assertEquals("cold-start-bandit-experiment-bandit", capturedBanditLog.experiment);
     assertEquals("control", capturedBanditLog.variation);
-    assertEquals("subject8", capturedBanditLog.subject);
+    assertEquals("subject10", capturedBanditLog.subject);
     assertEquals(Map.of(), capturedBanditLog.subjectAttributes);
     assertEquals("option0", capturedBanditLog.action);
     assertEquals(Map.of(), capturedBanditLog.actionAttributes);

--- a/src/test/java/com/eppo/sdk/EppoClientTest.java
+++ b/src/test/java/com/eppo/sdk/EppoClientTest.java
@@ -155,7 +155,7 @@ public class EppoClientTest {
   @MethodSource("getAssignmentTestData")
   void testAssignments(AssignmentTestCase testCase) {
 
-    // These test cases rely on the currently shared non-bandit RAC so we need to re-initialize our client to use that
+    // These test cases rely on the currently shared non-bandit RAC, so we need to re-initialize our client to use that
     String racResponseJson = getMockRandomizedAssignmentResponse("src/test/resources/rac-experiments-v3.json");
     this.mockServer.stubFor(
       WireMock.get(WireMock.urlMatching(".*randomized_assignment/v3/config\\?.*")).willReturn(WireMock.okJson(racResponseJson))
@@ -319,7 +319,7 @@ public class EppoClientTest {
     assertEquals("option3", capturedBanditLog.action);
     assertEquals(Map.of(), capturedBanditLog.actionAttributes);
     assertEquals(0.3333, capturedBanditLog.actionProbability, 0.0002);
-    assertEquals("cold start", capturedBanditLog.modelVersion);
+    assertEquals("uninitialized", capturedBanditLog.modelVersion);
   }
 
   @Test

--- a/src/test/java/com/eppo/sdk/EppoClientTest.java
+++ b/src/test/java/com/eppo/sdk/EppoClientTest.java
@@ -415,7 +415,7 @@ public class EppoClientTest {
 
     EppoAttributes subjectAttributes = new EppoAttributes(Map.of(
       "gender_identity", EppoValue.valueOf("male"),
-      "account_age", EppoValue.valueOf(200)
+      "account_age", EppoValue.valueOf(3)
     ));
 
     Map<String, EppoAttributes> actionAttributes = Map.of(
@@ -479,7 +479,7 @@ public class EppoClientTest {
 
     // get a nike assignment
     Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
-      "subject33",
+      "subject39",
       "banner-bandit-experiment",
       subjectAttributes,
       actions
@@ -491,7 +491,7 @@ public class EppoClientTest {
     ArgumentCaptor<BanditLogData> banditLogCaptor = ArgumentCaptor.forClass(BanditLogData.class);
     verify(mockBanditLogger, times(1)).logBanditAction(banditLogCaptor.capture());
     BanditLogData capturedBanditLog = banditLogCaptor.getValue();
-    assertEquals(0.1923, capturedBanditLog.actionProbability, 0.0002);
+    assertEquals(0.1613, capturedBanditLog.actionProbability, 0.0002);
   }
 
   @Test

--- a/src/test/java/com/eppo/sdk/EppoClientTest.java
+++ b/src/test/java/com/eppo/sdk/EppoClientTest.java
@@ -136,7 +136,7 @@ public class EppoClientTest {
         .willReturn(WireMock.okJson(banditResponseJson))
     );
 
-    // Re-initialize client with our bandit RAC and a mock logger we can spy on
+    // Initialize our client with the mock loggers we can spy on
     EppoClientConfig config = EppoClientConfig.builder()
       .apiKey("mock-api-key")
       .baseURL("http://localhost:4001")
@@ -155,7 +155,7 @@ public class EppoClientTest {
   @MethodSource("getAssignmentTestData")
   void testAssignments(AssignmentTestCase testCase) {
 
-    // These test cases rely on the currently shared non-bandit RAC
+    // These test cases rely on the currently shared non-bandit RAC so we need to re-initialize our client to use that
     String racResponseJson = getMockRandomizedAssignmentResponse("src/test/resources/rac-experiments-v3.json");
     this.mockServer.stubFor(
       WireMock.get(WireMock.urlMatching(".*randomized_assignment/v3/config\\?.*")).willReturn(WireMock.okJson(racResponseJson))

--- a/src/test/java/com/eppo/sdk/EppoClientTest.java
+++ b/src/test/java/com/eppo/sdk/EppoClientTest.java
@@ -346,7 +346,7 @@ public class EppoClientTest {
 
     EppoAttributes subjectAttributes = new EppoAttributes(Map.of(
       "gender_identity", EppoValue.valueOf("female"),
-      "days_since_signup", EppoValue.valueOf(130)
+      "days_since_signup", EppoValue.valueOf(130) // note: unused for scoring (which looks for account_age)
     ));
 
     Map<String, EppoAttributes> actionAttributes = Map.of(
@@ -388,7 +388,7 @@ public class EppoClientTest {
     assertEquals(subjectAttributes, capturedBanditLog.subjectAttributes);
     assertEquals("adidas", capturedBanditLog.action);
     assertEquals(actionAttributes.get("adidas"), capturedBanditLog.actionAttributes);
-    assertEquals(0.2042, capturedBanditLog.actionProbability, 0.0002);
+    assertEquals(0.2899, capturedBanditLog.actionProbability, 0.0002);
     assertEquals("falcon v123", capturedBanditLog.modelVersion);
   }
 
@@ -450,7 +450,7 @@ public class EppoClientTest {
     ArgumentCaptor<BanditLogData> banditLogCaptor = ArgumentCaptor.forClass(BanditLogData.class);
     verify(mockBanditLogger, times(1)).logBanditAction(banditLogCaptor.capture());
     BanditLogData capturedBanditLog = banditLogCaptor.getValue();
-    assertEquals(0.7622, capturedBanditLog.actionProbability, 0.0002);
+    assertEquals(0.8043, capturedBanditLog.actionProbability, 0.0002);
   }
 
   @Test
@@ -529,13 +529,14 @@ public class EppoClientTest {
     assertEquals("control", stringAssignment.get());
 
     // Manually log an action
-    EppoClient.getInstance().logNonBanditAction(
+    Exception banditLoggingException = EppoClient.getInstance().logNonBanditAction(
       "subject10",
       "cold-start-bandit-experiment",
       new EppoAttributes(),
       "option0",
       new EppoAttributes()
     );
+    assertNull(banditLoggingException);
 
     // Verify experiment assignment log
     ArgumentCaptor<AssignmentLogData> assignmentLogCaptor = ArgumentCaptor.forClass(AssignmentLogData.class);

--- a/src/test/java/com/eppo/sdk/EppoClientTest.java
+++ b/src/test/java/com/eppo/sdk/EppoClientTest.java
@@ -115,13 +115,19 @@ public class EppoClientTest {
     }
   }
 
+  private IAssignmentLogger mockAssignmentLogger = mock();
+  private IBanditLogger mockBanditLogger = mock();
+
   @BeforeEach
   void init() {
+    mockAssignmentLogger = mock();
+    mockBanditLogger = mock(); // Used in test cases that use testBanditModelActionLogging()
+
     setupMockRacServer("src/test/resources/rac-experiments-v3.json");
     EppoClientConfig config = EppoClientConfig.builder()
         .apiKey("mock-api-key")
         .baseURL("http://localhost:4001")
-        .assignmentLogger(mock())
+        .assignmentLogger(mockAssignmentLogger)
         .build();
     EppoClient.init(config);
   }
@@ -266,23 +272,7 @@ public class EppoClientTest {
 
   @Test
   public void testBanditColdStartAction() {
-    // For now, use our special bandits RAC until we fold it into the shared test case suite
-    String racResponseJson = getMockRandomizedAssignmentResponse("src/test/resources/bandits/rac-experiments-bandits-beta.json");
-    this.mockServer.stubFor(
-      WireMock.get(WireMock.urlMatching(".*randomized_assignment/v3/config\\?.*")).willReturn(WireMock.okJson(racResponseJson))
-    );
-    this.addBanditRacToMockServer(this.mockServer, "src/test/resources/bandits/bandits-parameters-1.json");
-
-    // Re-initialize client with our bandit RAC and a mock logger we can spy on
-    IAssignmentLogger mockAssignmentLogger = mock();
-    IBanditLogger mockBanditLogger = mock();
-    EppoClientConfig config = EppoClientConfig.builder()
-      .apiKey("mock-api-key")
-      .baseURL("http://localhost:4001")
-      .assignmentLogger(mockAssignmentLogger)
-      .banditLogger(mockBanditLogger)
-      .build();
-    EppoClient.init(config);
+    reinitializeClientForBandits();
 
     Set<String> banditActions = Set.of("option1", "option2", "option3");
 
@@ -325,24 +315,7 @@ public class EppoClientTest {
 
   @Test
   public void testBanditModelActionLogging() {
-    // For now, use our special bandits RAC until we fold it into the shared test case suite
-    String racResponseJson = getMockRandomizedAssignmentResponse("src/test/resources/bandits/rac-experiments-bandits-beta.json");
-    this.mockServer.stubFor(
-      WireMock.get(WireMock.urlMatching(".*randomized_assignment/v3/config\\?.*")).willReturn(WireMock.okJson(racResponseJson))
-    );
-    this.addBanditRacToMockServer(this.mockServer, "src/test/resources/bandits/bandits-parameters-1.json");
-
-    // Re-initialize client with our bandit RAC and a mock logger we can spy on
-    IAssignmentLogger mockAssignmentLogger = mock();
-    IBanditLogger mockBanditLogger = mock();
-    EppoClientConfig config = EppoClientConfig.builder()
-      .apiKey("mock-api-key")
-      .baseURL("http://localhost:4001")
-      .assignmentLogger(mockAssignmentLogger)
-      .banditLogger(mockBanditLogger)
-      .build();
-    EppoClient.init(config);
-
+    reinitializeClientForBandits();
 
     EppoAttributes subjectAttributes = new EppoAttributes(Map.of(
       "gender_identity", EppoValue.valueOf("female"),
@@ -394,24 +367,7 @@ public class EppoClientTest {
 
   @Test
   public void testBanditModelActionAssignmentFullContext() {
-    // For now, use our special bandits RAC until we fold it into the shared test case suite
-    String racResponseJson = getMockRandomizedAssignmentResponse("src/test/resources/bandits/rac-experiments-bandits-beta.json");
-    this.mockServer.stubFor(
-      WireMock.get(WireMock.urlMatching(".*randomized_assignment/v3/config\\?.*")).willReturn(WireMock.okJson(racResponseJson))
-    );
-    this.addBanditRacToMockServer(this.mockServer, "src/test/resources/bandits/bandits-parameters-1.json");
-
-    // Re-initialize client with our bandit RAC and a mock logger we can spy on
-    IAssignmentLogger mockAssignmentLogger = mock();
-    IBanditLogger mockBanditLogger = mock();
-    EppoClientConfig config = EppoClientConfig.builder()
-      .apiKey("mock-api-key")
-      .baseURL("http://localhost:4001")
-      .assignmentLogger(mockAssignmentLogger)
-      .banditLogger(mockBanditLogger)
-      .build();
-    EppoClient.init(config);
-
+    reinitializeClientForBandits();
 
     EppoAttributes subjectAttributes = new EppoAttributes(Map.of(
       "gender_identity", EppoValue.valueOf("male"),
@@ -455,24 +411,7 @@ public class EppoClientTest {
 
   @Test
   public void testBanditModelActionAssignmentNoContext() {
-    // For now, use our special bandits RAC until we fold it into the shared test case suite
-    String racResponseJson = getMockRandomizedAssignmentResponse("src/test/resources/bandits/rac-experiments-bandits-beta.json");
-    this.mockServer.stubFor(
-      WireMock.get(WireMock.urlMatching(".*randomized_assignment/v3/config\\?.*")).willReturn(WireMock.okJson(racResponseJson))
-    );
-    this.addBanditRacToMockServer(this.mockServer, "src/test/resources/bandits/bandits-parameters-1.json");
-
-    // Re-initialize client with our bandit RAC and a mock logger we can spy on
-    IAssignmentLogger mockAssignmentLogger = mock();
-    IBanditLogger mockBanditLogger = mock();
-    EppoClientConfig config = EppoClientConfig.builder()
-      .apiKey("mock-api-key")
-      .baseURL("http://localhost:4001")
-      .assignmentLogger(mockAssignmentLogger)
-      .banditLogger(mockBanditLogger)
-      .build();
-    EppoClient.init(config);
-
+    reinitializeClientForBandits();
 
     EppoAttributes subjectAttributes = new EppoAttributes();
     Set<String> actions = Set.of("nike", "adidas", "puma");
@@ -496,23 +435,7 @@ public class EppoClientTest {
 
   @Test
   public void testBanditControlAction() {
-    // For now, use our special bandits RAC until we fold it into the shared test case suite
-    String racResponseJson = getMockRandomizedAssignmentResponse("src/test/resources/bandits/rac-experiments-bandits-beta.json");
-    this.mockServer.stubFor(
-            WireMock.get(WireMock.urlMatching(".*randomized_assignment/v3/config\\?.*")).willReturn(WireMock.okJson(racResponseJson))
-    );
-    this.addBanditRacToMockServer(this.mockServer, "src/test/resources/bandits/bandits-parameters-1.json");
-
-    // Re-initialize client with our bandit RAC and a mock logger we can spy on
-    IAssignmentLogger mockAssignmentLogger = mock();
-    IBanditLogger mockBanditLogger = mock();
-    EppoClientConfig config = EppoClientConfig.builder()
-            .apiKey("mock-api-key")
-            .baseURL("http://localhost:4001")
-            .assignmentLogger(mockAssignmentLogger)
-            .banditLogger(mockBanditLogger)
-            .build();
-    EppoClient.init(config);
+    reinitializeClientForBandits();
 
     Set<String> banditActions = Set.of("option1", "option2", "option3");
 
@@ -565,21 +488,7 @@ public class EppoClientTest {
 
   @Test
   public void testBanditNotInAllocation() {
-    // For now, use our special bandits RAC until we fold it into the shared test case suite
-    String racResponseJson = getMockRandomizedAssignmentResponse("src/test/resources/bandits/rac-experiments-bandits-beta.json");
-    this.mockServer.stubFor(
-            WireMock.get(WireMock.urlMatching(".*randomized_assignment/v3/config\\?.*")).willReturn(WireMock.okJson(racResponseJson))
-    );
-    this.addBanditRacToMockServer(this.mockServer, "src/test/resources/bandits/bandits-parameters-1.json");
-
-    // Re-initialize client with our bandit RAC and a mock logger we can spy on
-    EppoClientConfig config = EppoClientConfig.builder()
-            .apiKey("mock-api-key")
-            .baseURL("http://localhost:4001")
-            .assignmentLogger(mock())
-            .banditLogger(mock())
-            .build();
-    EppoClient.init(config);
+    reinitializeClientForBandits();
 
     Set<String> banditActions = Set.of("option1", "option2", "option3");
 
@@ -593,5 +502,23 @@ public class EppoClientTest {
 
     // Verify assignment
     assertTrue(stringAssignment.isEmpty());
+  }
+
+  private void reinitializeClientForBandits() {
+    // For now, use our special bandits RAC until we fold it into the shared test case suite
+    String racResponseJson = getMockRandomizedAssignmentResponse("src/test/resources/bandits/rac-experiments-bandits-beta.json");
+    this.mockServer.stubFor(
+      WireMock.get(WireMock.urlMatching(".*randomized_assignment/v3/config\\?.*")).willReturn(WireMock.okJson(racResponseJson))
+    );
+    this.addBanditRacToMockServer(this.mockServer, "src/test/resources/bandits/bandits-parameters-1.json");
+
+    // Re-initialize client with our bandit RAC and a mock logger we can spy on
+    EppoClientConfig config = EppoClientConfig.builder()
+      .apiKey("mock-api-key")
+      .baseURL("http://localhost:4001")
+      .assignmentLogger(mockAssignmentLogger)
+      .banditLogger(mockBanditLogger)
+      .build();
+    EppoClient.init(config);
   }
 }

--- a/src/test/java/com/eppo/sdk/deserializer/BanditsDeserializerTest.java
+++ b/src/test/java/com/eppo/sdk/deserializer/BanditsDeserializerTest.java
@@ -21,8 +21,8 @@ class BanditsDeserializerTest {
         BanditParametersResponse responseObject = this.mapper.readValue(jsonString, BanditParametersResponse.class);
 
         assertEquals(1, responseObject.getBandits().size());
-        BanditParameters parameters = responseObject.getBandits().get("banner");
-        assertEquals("banner", parameters.getBanditKey());
+        BanditParameters parameters = responseObject.getBandits().get("banner-bandit");
+        assertEquals("banner-bandit", parameters.getBanditKey());
         assertEquals("falcon", parameters.getModelName());
         assertEquals("v123", parameters.getModelVersion());
 

--- a/src/test/java/com/eppo/sdk/deserializer/BanditsDeserializerTest.java
+++ b/src/test/java/com/eppo/sdk/deserializer/BanditsDeserializerTest.java
@@ -23,7 +23,7 @@ class BanditsDeserializerTest {
         assertEquals(1, responseObject.getBandits().size());
         BanditParameters parameters = responseObject.getBandits().get("banner");
         assertEquals("banner", parameters.getBanditKey());
-        assertEquals("falcon", parameters.getModel());
+        assertEquals("falcon", parameters.getModelName());
         assertEquals("v123", parameters.getModelVersion());
 
         BanditModelData modelData = parameters.getModelData();

--- a/src/test/java/com/eppo/sdk/deserializer/BanditsDeserializerTest.java
+++ b/src/test/java/com/eppo/sdk/deserializer/BanditsDeserializerTest.java
@@ -28,6 +28,8 @@ class BanditsDeserializerTest {
 
         BanditModelData modelData = parameters.getModelData();
         assertEquals(1.0, modelData.getGamma());
+        assertEquals(0.0, modelData.getDefaultActionScore());
+        assertEquals(0.0, modelData.getActionProbabilityFloor());
 
         Map<String, BanditCoefficients> coefficients = modelData.getCoefficients();
         assertEquals(2, coefficients.size());

--- a/src/test/resources/bandits/bandits-parameters-1.json
+++ b/src/test/resources/bandits/bandits-parameters-1.json
@@ -2,7 +2,7 @@
   "updatedAt": "2023-09-13T04:52:06.462Z",
   "bandits": [
     {
-      "banditKey": "banner",
+      "banditKey": "banner-bandit",
       "model": "falcon",
       "updatedAt": "2023-09-13T04:52:06.462Z",
       "modelVersion": "v123",

--- a/src/test/resources/bandits/bandits-parameters-1.json
+++ b/src/test/resources/bandits/bandits-parameters-1.json
@@ -3,11 +3,13 @@
   "bandits": [
     {
       "banditKey": "banner-bandit",
-      "model": "falcon",
+      "modelName": "falcon",
       "updatedAt": "2023-09-13T04:52:06.462Z",
       "modelVersion": "v123",
       "modelData": {
         "gamma": 1.0,
+        "defaultActionScore": 0.0,
+        "actionProbabilityFloor": 0.0,
         "coefficients": [
           {
             "actionKey": "nike",

--- a/src/test/resources/bandits/rac-experiments-bandits-beta.json
+++ b/src/test/resources/bandits/rac-experiments-bandits-beta.json
@@ -1,6 +1,6 @@
 {
   "flags": {
-    "test_bandit_1": {
+    "cold-start-bandit": {
       "subjectShards": 10000,
       "overrides": {},
       "typedOverrides": {},
@@ -14,6 +14,44 @@
       "allocations": {
         "bandit": {
           "percentExposure": 0.4533,
+          "variations": [
+            {
+              "name": "control",
+              "value": "control",
+              "typedValue": "control",
+              "shardRange": {
+                "start": 0,
+                "end": 2000
+              }
+            },
+            {
+              "name": "bandit",
+              "value": "banner-bandit",
+              "typedValue": "banner-bandit",
+              "shardRange": {
+                "start": 2000,
+                "end": 10000
+              },
+              "algorithmType": "bandit"
+            }
+          ]
+        }
+      }
+    },
+    "banner-bandit-experiment": {
+      "subjectShards": 10000,
+      "overrides": {},
+      "typedOverrides": {},
+      "enabled": true,
+      "rules": [
+        {
+          "allocationKey": "bandit",
+          "conditions": []
+        }
+      ],
+      "allocations": {
+        "bandit": {
+          "percentExposure": 1.0,
           "variations": [
             {
               "name": "control",

--- a/src/test/resources/bandits/rac-experiments-bandits-beta.json
+++ b/src/test/resources/bandits/rac-experiments-bandits-beta.json
@@ -1,6 +1,6 @@
 {
   "flags": {
-    "cold-start-bandit": {
+    "cold-start-bandit-experiment": {
       "subjectShards": 10000,
       "overrides": {},
       "typedOverrides": {},
@@ -26,8 +26,8 @@
             },
             {
               "name": "bandit",
-              "value": "banner-bandit",
-              "typedValue": "banner-bandit",
+              "value": "cold-start-bandit",
+              "typedValue": "cold-start-bandit",
               "shardRange": {
                 "start": 2000,
                 "end": 10000


### PR DESCRIPTION
_(Eppo Internal)_: 
🎟️ **Ticket:** [FF-1535 - Java Beta SDK Factors in Bandit Parameters for Selecting Actions](https://linear.app/eppo/issue/FF-1535/java-beta-sdk-factors-in-bandit-parameters-for-selecting-actions)
🗺️ Design Review - [Bandits Engineering Design](https://www.notion.so/eppo/Bandits-Engineering-Design-c5df5b6072b446aa8cacbf54e4d1f9df?pvs=4) (Relevant section: [Bandit RAC Component](https://www.notion.so/eppo/Bandits-Engineering-Design-c5df5b6072b446aa8cacbf54e4d1f9df?pvs=4#e6bc966bf3154d879d1be311b184a17c))

# Description

This pull request adds the ability for the SDK to use coefficients from the bandit parameters configuration to execute the FALCON algorithm ([Link to paper](https://arxiv.org/pdf/2003.12699.pdf), the algorithm is on Page 12). 

It does so with a newly created `FalconBanditModel` class, instantiated by `BanditModelFactory` when the bandit parameters indicate they are using the falcon model. Note that since any model other than randomly selecting an action will need additional parameters--not just the name--we pass the full bandit parameters to the `weighActions()` method now.

To help keep the code clean, we also introduce an `AttributeCoefficients` interface, which has a `scoreForAttributeValue()` method. This is implemented by the (deserialized) `BanditNumericAttributeCoefficients`and `BanditCategoricalAttributeCoefficients` classes and will return the value multiplied by the numeric coefficient for numeric coefficients and the relevant value for a given categorical value. If there is no recognized value, it will return the missing value coefficient.

To test the new model, a few test cases were added to `EppoClientTest`. Be sure to expand the "large diff." The expected weights were computed by "hand" in excel.

<img width="1048" alt="image" src="https://github.com/Eppo-exp/java-server-sdk-bandit-beta/assets/417605/8d9bf015-2b47-4fb0-9673-7cb120ed1c83">

Also, the dummy RAC was expanded to include an experiment with another bandit, `cold-start-bandit`, that is not present in the bandit parameters configuration. Test case was added that references this bandit to ensure we can handle unknown bandits/cold starts ok.