### PR TITLE
More fault tolerant reading of properties file

### DIFF
--- a/src/main/java/com/eppo/sdk/helpers/AppDetails.java
+++ b/src/main/java/com/eppo/sdk/helpers/AppDetails.java
@@ -1,9 +1,12 @@
 package com.eppo.sdk.helpers;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+@Slf4j
 public class AppDetails {
 
     static AppDetails instance;
@@ -12,18 +15,18 @@ public class AppDetails {
 
     public static AppDetails getInstance () {
         if (AppDetails.instance == null){
-            try {
-                AppDetails.instance = new AppDetails();
-            }
-            catch (Exception e) {
-                throw new RuntimeException("Unable to read properties file!");
-            }
+           AppDetails.instance = new AppDetails();
         }
         return AppDetails.instance;
     }
 
-    public AppDetails() throws IOException {
-        Properties prop = readPropertiesFile("app.properties");
+    public AppDetails() {
+        Properties prop = new Properties();
+        try {
+            prop = readPropertiesFile("app.properties");
+        } catch (IOException ex) {
+            log.warn("Unable to read properties file", ex);
+        }
         this.version = prop.getProperty("app.version", "1.0.0");
         this.name = prop.getProperty("app.name", "java-server-sdk");
     }


### PR DESCRIPTION
We have custom code to read `app.properties` to set the SDK version and name to initialize the client.

If, for some reason, this file cannot be read, currently, we fail to initialize the SDK and throw an error. Instead, we should log a warning.

I'm currently encountering this error when trying to initialize the SDK after loading it via JitPack.