### PR TITLE
Rename BANDIT algorithm type to CONTEXTUAL_BANDIT to match Eppo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.5.0</version>
+            <version>5.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/eppo/sdk/EppoClient.java
+++ b/src/main/java/com/eppo/sdk/EppoClient.java
@@ -64,11 +64,12 @@ public class EppoClient {
         String experimentKey = assignmentResult.getExperimentKey();
         String allocationKey = assignmentResult.getAllocationKey();
         String assignedVariationString = assignedVariation.getTypedValue().stringValue();
+        AlgorithmType algorithmType = assignedVariation.getAlgorithmType();
 
-        if (assignedVariation.getAlgorithmType() == AlgorithmType.OVERRIDE) {
+        if (algorithmType == AlgorithmType.OVERRIDE) {
             // Assigned variation was from an override; return its value without logging
             return assignmentValue;
-        } else if (assignedVariation.getAlgorithmType() == AlgorithmType.BANDIT) {
+        } else if (algorithmType == AlgorithmType.CONTEXTUAL_BANDIT) {
             // Assigned variation is a bandit; need to use the bandit to determine its value
             assignmentValue = this.determineAndLogBanditAction(assignmentResult, actionsWithAttributes);
         }

--- a/src/main/java/com/eppo/sdk/dto/AlgorithmType.java
+++ b/src/main/java/com/eppo/sdk/dto/AlgorithmType.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 
 public enum AlgorithmType {
     CONSTANT,
-    BANDIT,
+    CONTEXTUAL_BANDIT,
     OVERRIDE;
 
     @JsonCreator

--- a/src/main/java/com/eppo/sdk/helpers/AppDetails.java
+++ b/src/main/java/com/eppo/sdk/helpers/AppDetails.java
@@ -24,7 +24,7 @@ public class AppDetails {
         Properties prop = new Properties();
         try {
             prop = readPropertiesFile("app.properties");
-        } catch (IOException ex) {
+        } catch (Exception ex) {
             log.warn("Unable to read properties file", ex);
         }
         this.version = prop.getProperty("app.version", "1.0.0");
@@ -42,9 +42,8 @@ public class AppDetails {
     public static Properties readPropertiesFile(String fileName) throws IOException {
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
         Properties props = new Properties();
-        try(InputStream resourceStream = loader.getResourceAsStream(fileName)) {
-            props.load(resourceStream);
-        }
+        InputStream resourceStream = loader.getResourceAsStream(fileName);
+        props.load(resourceStream);
         return props;
     }
 

--- a/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
+++ b/src/main/java/com/eppo/sdk/helpers/ConfigurationStore.java
@@ -113,7 +113,7 @@ public class ConfigurationStore {
                     .getAllocations()
                     .values()
                     .stream().anyMatch(
-                      a -> a.getVariations().stream().anyMatch(v -> v.getAlgorithmType() == AlgorithmType.BANDIT)
+                      a -> a.getVariations().stream().anyMatch(v -> v.getAlgorithmType() == AlgorithmType.CONTEXTUAL_BANDIT)
                     );
 
                 if (configuration.isEnabled() && hasBanditVariation) {

--- a/src/test/java/com/eppo/sdk/helpers/AppDetailsTest.java
+++ b/src/test/java/com/eppo/sdk/helpers/AppDetailsTest.java
@@ -1,0 +1,50 @@
+package com.eppo.sdk.helpers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AppDetailsTest {
+
+  @BeforeEach
+  public void nullOutInstanceToReset() {
+    try {
+      Class<?> appDetailsClass = Class.forName("com.eppo.sdk.helpers.AppDetails");
+      Field instanceField = appDetailsClass.getDeclaredField("instance");
+      instanceField.setAccessible(true);
+      instanceField.set(null, null);
+    } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testReadAppProperties() {
+    AppDetails appDetails = AppDetails.getInstance();
+    assertEquals("java-server-sdk", appDetails.getName());
+    assertTrue(appDetails.getVersion().matches("^\\d+\\.\\d+\\.\\d+"));
+  }
+
+  @Test
+  public void testAppPropertyReadFailure() {
+      ClassLoader mockClassloader = Mockito.mock(ClassLoader.class);
+      Mockito.when(mockClassloader.getResourceAsStream("app.properties")).thenReturn(null);
+
+    ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(mockClassloader);
+      AppDetails.getInstance(); // Initialize with mock class loader
+    } finally {
+      Thread.currentThread().setContextClassLoader(originalClassLoader);
+    }
+
+    AppDetails appDetails = AppDetails.getInstance();
+    assertEquals("java-server-sdk", appDetails.getName());
+    assertEquals("1.0.0", appDetails.getVersion());
+  }
+}

--- a/src/test/resources/bandits/rac-experiments-bandits-beta.json
+++ b/src/test/resources/bandits/rac-experiments-bandits-beta.json
@@ -32,7 +32,7 @@
                 "start": 2000,
                 "end": 10000
               },
-              "algorithmType": "bandit"
+              "algorithmType": "CONTEXTUAL_BANDIT"
             }
           ]
         }
@@ -70,7 +70,7 @@
                 "start": 2000,
                 "end": 10000
               },
-              "algorithmType": "bandit"
+              "algorithmType": "CONTEXTUAL_BANDIT"
             }
           ]
         }


### PR DESCRIPTION
We use "CONTEXTUAL_BANDIT" now to be more specific and match what we generate in the RAC.

![image](https://github.com/Eppo-exp/java-server-sdk-bandit-beta/assets/417605/bf498d85-f2c5-4170-86f6-e5242255c429)
