### PR TITLE
Add test for cold start

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -15,6 +15,6 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: 'Set up GCP SDK'
-        uses: 'google-github-actions/setup-gcloud@v0'
+        uses: 'google-github-actions/setup-gcloud@v2'
       - name: Run tests
         run: make test

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -18,7 +18,7 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
       - name: 'Set up GCP SDK for downloading test data'
-        uses: 'google-github-actions/setup-gcloud@v0'
+        uses: 'google-github-actions/setup-gcloud@v2'
       - name: Download test data
         run: make test-data
       - name: Deploy package

--- a/src/main/java/com/eppo/sdk/helpers/VariationHelper.java
+++ b/src/main/java/com/eppo/sdk/helpers/VariationHelper.java
@@ -23,6 +23,6 @@ public class VariationHelper {
     }
 
     static public double variationProbability(Variation variation, int subjectShards) {
-        return (double)(variation.getShardRange().end - variation.getShardRange().start + 1) / subjectShards;
+        return (double)(variation.getShardRange().end - variation.getShardRange().start) / subjectShards;
     }
 }

--- a/src/test/java/com/eppo/sdk/EppoClientTest.java
+++ b/src/test/java/com/eppo/sdk/EppoClientTest.java
@@ -287,7 +287,7 @@ public class EppoClientTest {
 
     // Attempt to get a bandit assignment
     Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
-      "subject2",
+      "subject1",
       "cold-start-bandit-experiment",
       new EppoAttributes(),
       banditActions
@@ -305,7 +305,7 @@ public class EppoClientTest {
     assertEquals("cold-start-bandit-experiment", capturedAssignmentLog.featureFlag);
     assertEquals("bandit", capturedAssignmentLog.allocation);
     assertEquals("cold-start-bandit", capturedAssignmentLog.variation);
-    assertEquals("subject2", capturedAssignmentLog.subject);
+    assertEquals("subject1", capturedAssignmentLog.subject);
     assertEquals(Map.of(), capturedAssignmentLog.subjectAttributes);
 
     // Verify bandit log
@@ -314,10 +314,53 @@ public class EppoClientTest {
     BanditLogData capturedBanditLog = banditLogCaptor.getValue();
     assertEquals("cold-start-bandit-experiment-bandit", capturedBanditLog.experiment);
     assertEquals("cold-start-bandit", capturedBanditLog.variation);
-    assertEquals("subject2", capturedBanditLog.subject);
+    assertEquals("subject1", capturedBanditLog.subject);
     assertEquals(Map.of(), capturedBanditLog.subjectNumericAttributes);
     assertEquals(Map.of(), capturedBanditLog.subjectCategoricalAttributes);
-    assertEquals("option3", capturedBanditLog.action);
+    assertEquals("option1", capturedBanditLog.action);
+    assertEquals(Map.of(), capturedBanditLog.actionNumericAttributes);
+    assertEquals(Map.of(), capturedBanditLog.actionCategoricalAttributes);
+    assertEquals(0.3333, capturedBanditLog.actionProbability, 0.0002);
+    assertEquals("falcon cold start", capturedBanditLog.modelVersion);
+  }
+
+  @Test
+  public void testBanditUninitializedAction() {
+    Set<String> banditActions = Set.of("option1", "option2", "option3");
+
+    // Attempt to get a bandit assignment
+    Optional<String> stringAssignment = EppoClient.getInstance().getStringAssignment(
+      "subject8",
+      "uninitialized-bandit-experiment",
+      new EppoAttributes(),
+      banditActions
+    );
+
+    // Verify assignment
+    assertFalse(stringAssignment.isEmpty());
+    assertTrue(banditActions.contains(stringAssignment.get()));
+
+    // Verify experiment assignment log
+    ArgumentCaptor<AssignmentLogData> assignmentLogCaptor = ArgumentCaptor.forClass(AssignmentLogData.class);
+    verify(mockAssignmentLogger, times(1)).logAssignment(assignmentLogCaptor.capture());
+    AssignmentLogData capturedAssignmentLog = assignmentLogCaptor.getValue();
+    assertEquals("uninitialized-bandit-experiment-bandit", capturedAssignmentLog.experiment);
+    assertEquals("uninitialized-bandit-experiment", capturedAssignmentLog.featureFlag);
+    assertEquals("bandit", capturedAssignmentLog.allocation);
+    assertEquals("this-bandit-does-not-exist", capturedAssignmentLog.variation);
+    assertEquals("subject8", capturedAssignmentLog.subject);
+    assertEquals(Map.of(), capturedAssignmentLog.subjectAttributes);
+
+    // Verify bandit log
+    ArgumentCaptor<BanditLogData> banditLogCaptor = ArgumentCaptor.forClass(BanditLogData.class);
+    verify(mockBanditLogger, times(1)).logBanditAction(banditLogCaptor.capture());
+    BanditLogData capturedBanditLog = banditLogCaptor.getValue();
+    assertEquals("uninitialized-bandit-experiment-bandit", capturedBanditLog.experiment);
+    assertEquals("this-bandit-does-not-exist", capturedBanditLog.variation);
+    assertEquals("subject8", capturedBanditLog.subject);
+    assertEquals(Map.of(), capturedBanditLog.subjectNumericAttributes);
+    assertEquals(Map.of(), capturedBanditLog.subjectCategoricalAttributes);
+    assertEquals("option1", capturedBanditLog.action);
     assertEquals(Map.of(), capturedBanditLog.actionNumericAttributes);
     assertEquals(Map.of(), capturedBanditLog.actionCategoricalAttributes);
     assertEquals(0.3333, capturedBanditLog.actionProbability, 0.0002);

--- a/src/test/java/com/eppo/sdk/deserializer/BanditsDeserializerTest.java
+++ b/src/test/java/com/eppo/sdk/deserializer/BanditsDeserializerTest.java
@@ -20,7 +20,7 @@ class BanditsDeserializerTest {
         String jsonString = FileUtils.readFileToString(new File("src/test/resources/bandits/bandits-parameters-1.json"), "UTF8");
         BanditParametersResponse responseObject = this.mapper.readValue(jsonString, BanditParametersResponse.class);
 
-        assertEquals(1, responseObject.getBandits().size());
+        assertEquals(2, responseObject.getBandits().size());
         BanditParameters parameters = responseObject.getBandits().get("banner-bandit");
         assertEquals("banner-bandit", parameters.getBanditKey());
         assertEquals("falcon", parameters.getModelName());

--- a/src/test/resources/bandits/bandits-parameters-1.json
+++ b/src/test/resources/bandits/bandits-parameters-1.json
@@ -84,6 +84,18 @@
           }
         ]
       }
+    },
+    {
+      "banditKey": "cold-start-bandit",
+      "modelName": "falcon",
+      "updatedAt": "2023-09-13T04:52:06.462Z",
+      "modelVersion": "cold start",
+      "modelData": {
+        "gamma": 1.0,
+        "defaultActionScore": 0.0,
+        "actionProbabilityFloor": 0.0,
+        "coefficients": []
+      }
     }
   ]
 }

--- a/src/test/resources/bandits/rac-experiments-bandits-beta.json
+++ b/src/test/resources/bandits/rac-experiments-bandits-beta.json
@@ -13,7 +13,7 @@
       ],
       "allocations": {
         "bandit": {
-          "percentExposure": 0.4533,
+          "percentExposure": 1.0,
           "variations": [
             {
               "name": "control",
@@ -28,6 +28,44 @@
               "name": "bandit",
               "value": "cold-start-bandit",
               "typedValue": "cold-start-bandit",
+              "shardRange": {
+                "start": 2000,
+                "end": 10000
+              },
+              "algorithmType": "CONTEXTUAL_BANDIT"
+            }
+          ]
+        }
+      }
+    },
+    "uninitialized-bandit-experiment": {
+      "subjectShards": 10000,
+      "overrides": {},
+      "typedOverrides": {},
+      "enabled": true,
+      "rules": [
+        {
+          "allocationKey": "bandit",
+          "conditions": []
+        }
+      ],
+      "allocations": {
+        "bandit": {
+          "percentExposure": 0.4533,
+          "variations": [
+            {
+              "name": "control",
+              "value": "control",
+              "typedValue": "control",
+              "shardRange": {
+                "start": 0,
+                "end": 2000
+              }
+            },
+            {
+              "name": "bandit",
+              "value": "this-bandit-does-not-exist",
+              "typedValue": "this-bandit-does-not-exist",
               "shardRange": {
                 "start": 2000,
                 "end": 10000


### PR DESCRIPTION
_Eppo Internal:_ 🎟️ **Ticket: ** [FF-1599 - Add test to Bandits Beta SDK for cold start (no coefficients) vs uninitialized (no entry at all)](https://linear.app/eppo/issue/FF-1599/add-test-to-bandits-beta-sdk-for-cold-start-no-coefficients-vs)

When working on generating the bandit RAC (see [this comment](https://github.com/Eppo-exp/eppo/pull/8785#discussion_r1496924436) in `Eppo` PR [#8785](https://github.com/Eppo-exp/eppo/pull/8785)) we realized there are two different situations where a bandit would select a random action:
1. **Uninitialized** - We have no knowledge of the bandit (i.e., the bandit key is unrecognized)
2. **Cold Start** - We know about the bandit (e.g., it's created) but haven't trained it (i.e., no model parameters yet)

If our UI/UX works as expected, the first one--an uninitialized bandit--_shouldn't_ happen. However, we still want the SDK to handle the case should it arrive.

This PR renamed the test of an uninitialized bandit to better reflect what is happening, and adds a new test for a cold-start bandit.
